### PR TITLE
Fix issues reported by shellcheck

### DIFF
--- a/slapd-config
+++ b/slapd-config
@@ -27,17 +27,17 @@ AUTHENTICATION="${AUTHENTICATION:--Q -H ldapi:/// -Y EXTERNAL}"
 
 # detect base64 encoder/decoder
 if which base64 &>/dev/null; then
-	B64ENC="base64"
-	B64DEC="base64 -d"
+	B64ENC=( base64 )
+	B64DEC=( base64 -d )
 elif which openssl &>/dev/null; then
-	B64ENC="openssl base64"
-	B64DEC="openssl base64 -d"
+	B64ENC=( openssl base64 )
+	B64DEC=( openssl base64 -d )
 elif which recode &>/dev/null; then
-	B64ENC="recode ..base64"
-	B64DEC="recode base64.."
+	B64ENC=( recode ..base64 )
+	B64DEC=( recode base64.. )
 else
-	B64ENC="echo 'missing base64 encoder' >&2 && exit 5"
-	B64DEC="echo 'missing base64 decoder' >&2 && exit 5"
+	B64ENC=( echo 'missing base64 encoder' \>\&2 \&\& exit 5 )
+	B64DEC=( echo 'missing base64 decoder' \>\&2 \&\& exit 5 )
 fi
 
 
@@ -57,14 +57,15 @@ findEntries()
 
 	shift
 
+	# shellcheck disable=SC2086
 	ldapsearch $AUTHENTICATION -LLL -b "$basedn" "$query" "$@" | sed -ne '/^ *$/!p' | sed -ne '1h;1!H;${;x;s/\n //g;p;}'
 }
 
 DBName2DN()
 {
-	for dn in `listDatabaseDNs`; do
-		name="`DBDN2Name "$dn"`"
-		[ "${1}" = "$name" -o "${1}" = "${name#*\}}" ] && { echo $dn; return 0; }
+	for dn in $(listDatabaseDNs); do
+		name="$(DBDN2Name "$dn")"
+		[ "${1}" = "$name" ] || [ "${1}" = "${name#*\}}" ] && { echo "$dn"; return 0; }
 	done
 
 	echo "invalid database: ${1}" >&2
@@ -82,7 +83,7 @@ values2LDIF()
 	values=
 	i=0
 
-	while read line; do
+	while read -r line; do
 		# insert line break
 		[ $i -eq 0 ] || values="$values\n"
 
@@ -91,14 +92,14 @@ values2LDIF()
 
 		# base64-encode line if required
 		echo -n "$line" | awk '/^[\x01-\x09\x0B\x0C\x0E-\x1F\x21-\x39\x3B\x3D-\x7F][\x01-\x09\x0B\x0C\x0E-\x7F]*$/ {print "valid"}' | grep valid &>/dev/null || {
-			line="$(echo -n "$line" | $B64ENC)"
+			line="$(echo -n "$line" | "${B64ENC[@]}")"
 		}
 
 		values="$values${1}: ${line}"
 		i=$((i+1))
 	done
 
-	{ [ $i -lt 2 -a "${2}" != "nonumbers" ] && sed 's/^\([^:]\+: \){0}/\1/' <<<"$values" || echo "$values"; } | sed 's/\\n/\n/g' | sed -n ':p;s/\([^\n]\{78\}\)\([^\n]\)/\1\n \2/;tp;p'
+	{ [ $i -lt 2 ] && [ "${2}" != "nonumbers" ] && sed 's/^\([^:]\+: \){0}/\1/' <<<"$values" || echo "$values"; } | sed 's/\\n/\n/g' | sed -n ':p;s/\([^\n]\{78\}\)\([^\n]\)/\1\n \2/;tp;p'
 }
 
 listEntries()
@@ -129,13 +130,13 @@ readAttribute()
 /^'"$attr"':/!d
 s/^'"$attr"': *\({\(-\?[0-9][0-9]*\)}\)\?/=/
 s/^'"$attr"':: */!/
-p' | while read line; do
+p' | while read -r line; do
 		case "${line:0:1}" in
 			"=")
 				echo "${line:1}"
 				;;
 			'!')
-				echo -n "${line:1}" | $B64DEC
+				echo -n "${line:1}" | "${B64DEC[@]}"
 				;;
 		esac
 	done
@@ -147,6 +148,7 @@ writeAttribute()
 	attr="${2}"
 	[ "${3}" = "nonumbers" ] && mode=nonumbers || mode=
 
+	# shellcheck disable=SC2086
 	ldapmodify $AUTHENTICATION <<EOT
 dn: $dn
 changetype: modify
@@ -163,11 +165,11 @@ insertAttributeLine()
 	idx="${3}"
 	rule="${4//;/\\;}"
 
-	[ $idx -lt 1 ] && idx=1
+	[ "$idx" -lt 1 ] && idx=1
 
 	{
 		readAttribute "$dn" "$attr" | {
-			if [ $idx -le $(readAttribute "$dn" "$attr" | wc -l) ]; then
+			if [ "$idx" -le "$(readAttribute "$dn" "$attr" | wc -l)" ]; then
 				sed "${idx}i${rule}"
 			else
 				sed -n "p;\$i${rule}"
@@ -182,7 +184,10 @@ deleteAttributeLine()
 	attr="${2}"
 	idx="${3}"
 
-	[ $idx -ge 1 -a $idx -le `readAttribute "$dn" "$attr" | wc -l` ] || { echo "index out of bound" >&2; return 1; }
+	if ! [ "$idx" -ge 1 ] && [ "$idx" -le "$(readAttribute "$dn" "$attr" | wc -l)" ] ; then
+		echo "index out of bound" >&2
+		return 1
+	fi
 
 	readAttribute "$dn" "$attr" | sed "${idx}d" | writeAttribute "$dn" "$attr" "${4}"
 }
@@ -191,15 +196,16 @@ schema2CN()
 {
 	name="${1}"
 
-	grep -E '^[1-9][0-9]*$' <<<$name &>/dev/null && index="$((name-1))" || index="x"
+	grep -E '^[1-9][0-9]*$' <<<"$name" &>/dev/null && index="$((name-1))" || index="x"
 
-	cn=`findEntries -dn 'cn=schema,cn=config' 'objectClass=*' dn -s one | sed "/^dn: cn={$index}.\|}$name,cn=schema,cn=config\$/!d;s/^[^{]\+\({[^,]\+\),cn=schema,cn=config\$/\1/"`
+	cn=$(findEntries -dn 'cn=schema,cn=config' 'objectClass=*' dn -s one | sed "/^dn: cn={$index}.\|}$name,cn=schema,cn=config\$/!d;s/^[^{]\+\({[^,]\+\),cn=schema,cn=config\$/\1/")
 
-	if [ $? -ne 0 -o -z "`echo "$cn"`" ]; then
+	# shellcheck disable=SC2181
+	if [ $? -ne 0 ] || [ -z "$cn" ]; then
 		if [ -n "${2}" ]; then
 			idx=-1
-			for cidx in `findEntries -dn 'cn=schema,cn=config' 'objectClass=*' dn -s one | sed -n 's/^[^{]\+{\([0-9]\+\)}.*$/\1/p'`; do
-				[ $cidx -gt $idx ] && idx=$cidx
+			for cidx in $(findEntries -dn 'cn=schema,cn=config' 'objectClass=*' dn -s one | sed -n 's/^[^{]\+{\([0-9]\+\)}.*$/\1/p'); do
+				[ "$cidx" -gt "$idx" ] && idx=$cidx
 			done
 
 			echo "{$((idx+1))}$name"
@@ -207,13 +213,13 @@ schema2CN()
 			return 1
 		fi
 	else
-		echo $cn
+		echo "$cn"
 	fi
 }
 
 schema2DN()
 {
-	cn="`schema2CN "${1}"`" || return 1
+	cn="$(schema2CN "${1}")" || return 1
 	echo "cn=${cn},cn=schema,cn=config"
 }
 
@@ -235,17 +241,17 @@ testSchema()
 
 readSchema()
 {
-	dn="`schema2DN "${1}"`" || { echo "invalid or missing schema" >&2; exit 1; }
+	dn="$(schema2DN "${1}")" || { echo "invalid or missing schema" >&2; exit 1; }
 
 	cat <<EOT
-# Copy of schema `readAttribute "$dn" cn`
+# Copy of schema $(readAttribute "$dn" cn)
 # DN in LDAP is $dn
 
-`readAttribute "$dn" olcObjectIdentifier | sed 's/^/\nobjectidentifier /;s/ \(NAME\|DESC\|EQUALITY\|SUBSTR\|SYNTAX\|SINGLE-VALUE\|SUP\)/\n\t\1/g'`
+$(readAttribute "$dn" olcObjectIdentifier | sed 's/^/\nobjectidentifier /;s/ \(NAME\|DESC\|EQUALITY\|SUBSTR\|SYNTAX\|SINGLE-VALUE\|SUP\)/\n\t\1/g')
 
-`readAttribute "$dn" olcAttributeTypes | sed 's/^/\nattributetype /;s/ \(NAME\|DESC\|EQUALITY\|SUBSTR\|SYNTAX\|SINGLE-VALUE\|SUP\)/\n\t\1/g'`
+$(readAttribute "$dn" olcAttributeTypes | sed 's/^/\nattributetype /;s/ \(NAME\|DESC\|EQUALITY\|SUBSTR\|SYNTAX\|SINGLE-VALUE\|SUP\)/\n\t\1/g')
 
-`readAttribute "$dn" olcObjectClasses | sed 's/^/\nobjectclass /;s/ \(NAME\|DESC\|SUP\|STRUCTURAL\|AUXILIARY\|MAY\|MUST\)/\n\t\1/g'`
+$(readAttribute "$dn" olcObjectClasses | sed 's/^/\nobjectclass /;s/ \(NAME\|DESC\|SUP\|STRUCTURAL\|AUXILIARY\|MAY\|MUST\)/\n\t\1/g')
 EOT
 }
 
@@ -260,7 +266,7 @@ schemaFileToLDIF()
 		aline=""
 		cline=""
 
-		while read rule; do
+		while read -r rule; do
 			ruletype="${rule%% *}"
 			case "${ruletype,,}" in
 				objectidentifier)
@@ -301,6 +307,7 @@ writeSchema()
 		read -r classes
 
 		testSchema "${1}"
+		# shellcheck disable=SC2181
 		if [ $? -eq 0 ]; then
 			dn="$(schema2DN "${1}")"
 
@@ -323,6 +330,7 @@ $(sed 's/\\n/\n/g' <<<"$classes")
 -
 "
 
+			# shellcheck disable=SC2086
 			ldapmodify $AUTHENTICATION <<<"$ldif"
 		else
 			cn="$(schema2CN "${1}" y)"
@@ -341,6 +349,7 @@ cn: ${cn}
 			[ -n "$classes" ] && ldif="${ldif}$(sed 's/\\n/\n/g' <<<"$classes")
 "
 
+			# shellcheck disable=SC2086
 			ldapadd $AUTHENTICATION <<<"$ldif"
 		fi
 	)
@@ -348,18 +357,20 @@ cn: ${cn}
 
 deleteSchema()
 {
-	dn="`schema2DN "${1}"`" || { echo "invalid or missing schema" >&2; exit 1; }
+	dn="$(schema2DN "${1}")" || { echo "invalid or missing schema" >&2; exit 1; }
 
 	idx="${dn#*{}"
 	idx="${idx%%\}*}"
 
+	# shellcheck disable=SC2086
 	ldapdelete $AUTHENTICATION "${dn}" || { echo "failed to delete schema ${dn}" >&2; exit 2; }
 
 	while testSchema "$((idx+1))"; do
-		olddn="`schema2DN "$((idx+1))"`"
-		newcn="`DN2Schema "${olddn}"`"
+		olddn="$(schema2DN "$((idx+1))")"
+		newcn="$(DN2Schema "${olddn}")"
 		newcn="{$idx}$newcn"
 
+		# shellcheck disable=SC2086
 		ldapmodify $AUTHENTICATION <<-EOT
 dn: ${olddn}
 changetype: modrdn
@@ -369,6 +380,7 @@ newsuperior: cn=schema,cn=config
 -
 		EOT
 
+		# shellcheck disable=SC2181
 		[ $? -ne 0 ] && { echo "failed to move schema $olddn to cn=$newcn,cn=schema,cn=config" >&2; exit 2; }
 	done
 }
@@ -380,17 +392,17 @@ listDatabaseDNs()
 
 listAllDatabases()
 {
-	for dn in `listDatabaseDNs`; do
-		echo "`DBDN2Name "$dn"`	$dn"
+	for dn in $(listDatabaseDNs); do
+		echo "$(DBDN2Name "$dn")	$dn"
 	done
 }
 
 listDatabases()
 {
-	for dn in `listDatabaseDNs`
+	for dn in $(listDatabaseDNs)
 	do
-		if suffix=`findEntries -dn "$dn" "olcSuffix=*" olcSuffix | grep -E '^olcSuffix: '`; then
-			echo "`DBDN2Name "$dn"`	${suffix#*: }	$dn"
+		if suffix=$(findEntries -dn "$dn" "olcSuffix=*" olcSuffix | grep -E '^olcSuffix: '); then
+			echo "$(DBDN2Name "$dn")	${suffix#*: }	$dn"
 		fi
 	done
 }
@@ -409,24 +421,26 @@ writeSslCertificate()
 		[ -f "$caFilename" ] || { echo "missing CA certificate file: $caFilename" >&2; exit 1; }
 
 		echo "setting up CA certificate file" >&2
+		# shellcheck disable=SC2086
 		ldapmodify $AUTHENTICATION <<-EOT
 dn: cn=config
 changetype: modify
 replace: olcTLSCACertificateFile
-`values2LDIF olcTLSCACertificateFile <<<"$caFilename"`
+$(values2LDIF olcTLSCACertificateFile <<<"$caFilename")
 -
 		EOT
 	fi
 
 	echo "setting up certificate/key files" >&2
+	# shellcheck disable=SC2086
 	ldapmodify $AUTHENTICATION <<-EOT
 dn: cn=config
 changetype: modify
 replace: olcTLSCertificateFile
-`values2LDIF olcTLSCertificateFile <<<"$certFilename"`
+$(values2LDIF olcTLSCertificateFile <<<"$certFilename")
 -
 replace: olcTLSCertificateKeyFile
-`values2LDIF olcTLSCertificateKeyFile <<<"$keyFilename"`
+$(values2LDIF olcTLSCertificateKeyFile <<<"$keyFilename")
 -
 	EOT
 }
@@ -436,6 +450,7 @@ deleteSslCertificate()
 	if [ -n "$(readAttribute "cn=config" "olcTLSCertificateFile")" ]
 	then
 		echo "dropping certificate/key file" >&2
+		# shellcheck disable=SC2086
 		ldapmodify $AUTHENTICATION <<-EOT
 dn: cn=config
 changetype: modify
@@ -449,6 +464,7 @@ delete: olcTLSCertificateKeyFile
 	if [ -n "$(readAttribute "cn=config" "olcTLSCACertificateFile")" ]
 	then
 		echo "dropping CA certificate file" >&2
+		# shellcheck disable=SC2086
 		ldapmodify $AUTHENTICATION <<-EOT
 dn: cn=config
 changetype: modify
@@ -643,14 +659,17 @@ actions are:
 				;;
 			write)
 				[ $# -lt 2 ] && usage <<<"usage: $APPNAME db write <dbname> <attr> [ nonumbers ]\n       (providing value lines on stdin)\n"
+				# shellcheck disable=SC2086
 				writeAttribute "$(DBName2DN "${1}")" "${2}" ${3}
 				;;
 			insert)
 				[ $# -lt 4 ] && usage <<<"usage: $APPNAME db insert <dbname> <attr> <linenum> \"<value>\" [ nonumbers ]\n"
+				# shellcheck disable=SC2086
 				insertAttributeLine "$(DBName2DN "${1}")" "${2}" "${3}" "${4}" ${5}
 				;;
 			delete)
 				[ $# -lt 3 ] && usage <<<"usage: $APPNAME db delete <dbname> <attr> <linenum> [ nonumbers ]\n"
+				# shellcheck disable=SC2086
 				deleteAttributeLine "$(DBName2DN "${1}")" "${2}" "${3}" ${4}
 				;;
 			read-access)


### PR DESCRIPTION
This patch includes fixes to warnings and errors reported by the
shellcheck v0.4.6 linter script.

Some of the issues imported by the linter were ignored, since fixing
them would require more involved refactoring of the script. Hopefully
these issues can be fixed at a later time.